### PR TITLE
Enable automatic notion relay publishing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,13 @@
+# Notion Relay Configuration
+# Optional: limits how many pages we create per collection
+NOTION_RELAY_MAX_PAGES=10
+
+# Required for publishing (plan works without these)
+NOTION_TOKEN=
+NOTION_DB_HEARTBEAT_ID=
+NOTION_DB_FINANCIAL_MODELS_ID=
+NOTION_DB_CLIENT_CONFIGS_ID=
+
 # Teamwork MCP Configuration
 # Copy this file to .env and update with your actual values
 

--- a/.github/workflows/notion-relay.yml
+++ b/.github/workflows/notion-relay.yml
@@ -1,0 +1,52 @@
+name: Notion Relay
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - 'scripts/notion-relay-publish.js'
+      - 'codex/collaboration/notion-relay.json'
+      - '.github/workflows/notion-relay.yml'
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Use Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install
+        run: npm ci
+      - name: Generate plan
+        run: npm run notion:relay:plan > notion-relay-plan.json
+      - name: Upload plan artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: notion-relay-plan
+          path: notion-relay-plan.json
+
+  publish:
+    needs: plan
+    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/heads/main') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Use Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install
+        run: npm ci
+      - name: Publish to Notion
+        env:
+          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+          NOTION_DB_HEARTBEAT_ID: ${{ secrets.NOTION_DB_HEARTBEAT_ID }}
+          NOTION_DB_FINANCIAL_MODELS_ID: ${{ secrets.NOTION_DB_FINANCIAL_MODELS_ID }}
+          NOTION_DB_CLIENT_CONFIGS_ID: ${{ secrets.NOTION_DB_CLIENT_CONFIGS_ID }}
+          NOTION_RELAY_MAX_PAGES: ${{ vars.NOTION_RELAY_MAX_PAGES }}
+        run: npm run notion:relay:publish
+

--- a/codex/collaboration/notion-relay.json
+++ b/codex/collaboration/notion-relay.json
@@ -1,0 +1,29 @@
+{
+  "heartbeat": {
+    "schema_mapping": {
+      "Name": { "type": "title" },
+      "Status": { "type": "select" },
+      "Tags": { "type": "multi_select" }
+    },
+    "items": [
+      { "Name": "Relay Heartbeat", "Status": "GREEN", "Tags": ["relay", "heartbeat"] }
+    ]
+  },
+  "financial_models": {
+    "schema_mapping": {
+      "Name": { "type": "title" },
+      "ARR": { "type": "number" },
+      "Stage": { "type": "select" }
+    },
+    "items": []
+  },
+  "client_configs": {
+    "schema_mapping": {
+      "Name": { "type": "title" },
+      "ClientId": { "type": "rich_text" },
+      "Tier": { "type": "select" }
+    },
+    "items": []
+  }
+}
+

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "prepare": "npm run build",
     "watch": "tsc --watch",
     "inspector": "tsc && node -e \"const fs = require('fs'); if (fs.existsSync('.env.example')) { fs.copyFileSync('.env.example', 'build/.env'); } fs.chmodSync('build/index.js', '755')\" && npx @modelcontextprotocol/inspector build/index.js",
-    "test-connection": "node test-connection.js"
+    "test-connection": "node test-connection.js",
+    "notion:relay:plan": "node scripts/notion-relay-publish.js",
+    "notion:relay:publish": "node scripts/notion-relay-publish.js --publish"
   },
   "files": [
     "build",
@@ -39,6 +41,7 @@
   "homepage": "https://github.com/vizioz/teamwork-mcp#readme",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.6.1",
+    "@notionhq/client": "^2.2.15",
     "@types/minimist": "^1.2.5",
     "axios": "^1.8.2",
     "dotenv": "^16.4.5",

--- a/scripts/notion-relay-publish.js
+++ b/scripts/notion-relay-publish.js
@@ -82,7 +82,7 @@ async function main() {
         if (val == null || val === "") continue;
         properties[propName] = { select: { name: String(val) } };
       } else if (type === "multi_select") {
-        const arr = Array.isArray(val) ? val : (val != null ? [val] : []);
+        const arr = Array.isArray(val) ? val : (val !== null && val !== undefined ? [val] : []);
         properties[propName] = { multi_select: arr.map((x) => ({ name: String(x) })) };
       } else if (type === "created_time") {
         // Notion ignores created_time on create; skip to avoid errors

--- a/scripts/notion-relay-publish.js
+++ b/scripts/notion-relay-publish.js
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+async function main() {
+  const shouldPublish = process.argv.includes("--publish");
+  const rootDir = path.resolve(__dirname, "..");
+  const mappingPath = path.join(rootDir, "codex", "collaboration", "notion-relay.json");
+
+  const maxPages = parseInt(process.env.NOTION_RELAY_MAX_PAGES || "10", 10);
+  const token = process.env.NOTION_TOKEN || "";
+  const heartbeatDb = process.env.NOTION_DB_HEARTBEAT_ID || "";
+  const finDb = process.env.NOTION_DB_FINANCIAL_MODELS_ID || "";
+  const clientDb = process.env.NOTION_DB_CLIENT_CONFIGS_ID || "";
+
+  /** Safe no-op when secrets missing */
+  const canPublish = Boolean(token);
+
+  const exists = fs.existsSync(mappingPath);
+  if (!exists) {
+    console.error(`[notion-relay] mapping file missing: ${mappingPath}`);
+    process.exit(2);
+  }
+
+  const mapping = JSON.parse(fs.readFileSync(mappingPath, "utf8"));
+
+  const plan = [];
+
+  function addPlan(kind, dbId, items) {
+    if (!Array.isArray(items) || items.length === 0) return;
+    const limited = items.slice(0, maxPages);
+    plan.push({ kind, dbId, count: limited.length });
+  }
+
+  addPlan("heartbeat", heartbeatDb, mapping.heartbeat?.items || []);
+  addPlan("financial_models", finDb, mapping.financial_models?.items || []);
+  addPlan("client_configs", clientDb, mapping.client_configs?.items || []);
+
+  if (!shouldPublish) {
+    console.log(JSON.stringify({ mode: "plan", canPublish, maxPages, plan }, null, 2));
+    return;
+  }
+
+  if (!canPublish) {
+    console.log(JSON.stringify({ mode: "publish", skipped: true, reason: "missing NOTION_TOKEN", plan }, null, 2));
+    return;
+  }
+
+  const { Client } = require("@notionhq/client");
+  const notion = new Client({ auth: token });
+
+  async function publishGroup(kind, dbId, schema, items) {
+    if (!dbId) return { kind, dbId, published: 0, skipped: items.length, reason: "missing database id" };
+    const limited = items.slice(0, maxPages);
+    let published = 0;
+    for (const item of limited) {
+      const properties = buildPropertiesFromSchema(schema, item);
+      try {
+        await notion.pages.create({ parent: { database_id: dbId }, properties });
+        published += 1;
+      } catch (err) {
+        // continue on error, report summary only
+      }
+    }
+    return { kind, dbId, published, attempted: limited.length };
+  }
+
+  function buildPropertiesFromSchema(schema, item) {
+    const properties = {};
+    for (const [propName, spec] of Object.entries(schema || {})) {
+      const type = spec.type;
+      const val = item[propName];
+      if (type === "title") {
+        properties[propName] = { title: [{ type: "text", text: { content: String(val ?? "") } }] };
+      } else if (type === "rich_text") {
+        properties[propName] = { rich_text: [{ type: "text", text: { content: String(val ?? "") } }] };
+      } else if (type === "number") {
+        properties[propName] = { number: typeof val === "number" ? val : Number(val ?? 0) };
+      } else if (type === "select") {
+        if (val == null || val === "") continue;
+        properties[propName] = { select: { name: String(val) } };
+      } else if (type === "multi_select") {
+        const arr = Array.isArray(val) ? val : (val != null ? [val] : []);
+        properties[propName] = { multi_select: arr.map((x) => ({ name: String(x) })) };
+      } else if (type === "created_time") {
+        // Notion ignores created_time on create; skip to avoid errors
+        continue;
+      }
+    }
+    return properties;
+  }
+
+  const results = [];
+  if (mapping.heartbeat?.items?.length) {
+    results.push(await publishGroup("heartbeat", heartbeatDb, mapping.heartbeat.schema_mapping, mapping.heartbeat.items));
+  }
+  if (mapping.financial_models?.items?.length) {
+    results.push(await publishGroup("financial_models", finDb, mapping.financial_models.schema_mapping, mapping.financial_models.items));
+  }
+  if (mapping.client_configs?.items?.length) {
+    results.push(await publishGroup("client_configs", clientDb, mapping.client_configs.schema_mapping, mapping.client_configs.items));
+  }
+
+  console.log(JSON.stringify({ mode: "publish", canPublish, maxPages, results }, null, 2));
+}
+
+main().catch((err) => {
+  console.error("[notion-relay] fatal", err);
+  process.exit(1);
+});
+


### PR DESCRIPTION
Enable automatic Notion publishing for the relay to publish heartbeat, financial model, and client configuration data.

---
<a href="https://cursor.com/background-agent?bcId=bc-d909ddfa-aada-47bf-898f-5206d603d53d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d909ddfa-aada-47bf-898f-5206d603d53d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

