### PR TITLE
Public repository remediation

### DIFF
--- a/scripts/public_repo_remediate.sh
+++ b/scripts/public_repo_remediate.sh
@@ -120,7 +120,7 @@ classify_repo() {
     risk="YELLOW"
   fi
 
-  if (cd "$repo_dir" && git ls-files | rg -i -q "$RED_REGEX"); then
+  if (cd "$repo_dir" && git ls-files | grep -E -i -q "$RED_REGEX"); then
     risk="RED"
   fi
 
@@ -212,7 +212,7 @@ IGN
   git config user.email >/dev/null 2>&1 || git config user.email "codex@activ8ai.app"
 
   # Append ignore block only if missing marker line
-  if ! rg -q "Charter Standard: Never commit secrets/caches/artifacts" .gitignore 2>/dev/null; then
+  if ! grep -q "Charter Standard: Never commit secrets/caches/artifacts" .gitignore 2>/dev/null; then
     printf "\n%s\n" "$ignore_block" >> .gitignore
   fi
 
@@ -244,7 +244,6 @@ main() {
   require_cmd jq
   require_cmd git
   require_cmd git-filter-repo
-  require_cmd rg
 
   while [[ $# -gt 0 ]]; do
     case "$1" in

--- a/scripts/public_repo_remediate.sh
+++ b/scripts/public_repo_remediate.sh
@@ -212,7 +212,7 @@ IGN
   git config user.email >/dev/null 2>&1 || git config user.email "codex@activ8ai.app"
 
   # Append ignore block only if missing marker line
-  if ! grep -q "Charter Standard: Never commit secrets/caches/artifacts" .gitignore 2>/dev/null; then
+  if ! grep -F -q "Charter Standard: Never commit secrets/caches/artifacts" .gitignore 2>/dev/null; then
     printf "\n%s\n" "$ignore_block" >> .gitignore
   fi
 


### PR DESCRIPTION
## Summary

This change removes the `ripgrep` (rg) dependency from the `public_repo_remediate.sh` script, replacing its usage with standard `grep -E` commands.

## Context

- Issue(s): #N/A
- Objective and scope: To align the repository's remediation automation script (`public_repo_remediate.sh`) with a "Charter-standard" specification, ensuring it runs on a standard Mac setup with only `gh`, `git-filter-repo`, `jq`, and `git` as external dependencies. The previous version required `ripgrep`.

## Changes

- Replaced `rg -i -q` with `grep -E -i -q` in the `classify_repo` function.
- Replaced `rg -q` with `grep -q` in the `ensure_gitignore_and_head_cleanup` function.
- Removed the `require_cmd rg` check from the `main` function.

## Risks / Trade-offs

- `grep` might be marginally slower than `ripgrep` for certain operations, but for the specific uses in this script (processing `git ls-files` output and checking `.gitignore`), the performance difference is expected to be negligible.
- `grep -E` provides equivalent extended regular expression capabilities for the patterns used.

## Testing

- The script was modified and committed locally.
- Local execution of the script was performed to confirm the dependency removal and basic functionality.
- Further testing against the repository's configured checks (from `package.json` and Python `tests/` suite) is planned.

## Checklist

- [ ] Build passes locally (`npm run build`)
- [ ] Docs updated (README/docs)

---
<a href="https://cursor.com/background-agent?bcId=bc-3b640dfe-fa1d-4d7e-9359-3c8a6c2100e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3b640dfe-fa1d-4d7e-9359-3c8a6c2100e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reduces external dependencies of `scripts/public_repo_remediate.sh` by replacing `ripgrep` usage with standard `grep`.
> 
> - In `classify_repo`, swap `rg -i -q` for `grep -E -i -q` on `git ls-files`
> - In `ensure_gitignore_and_head_cleanup`, replace `rg -q` check with `grep -q`
> - Remove `require_cmd rg` from `main` (now relies on `gh`, `git-filter-repo`, `jq`, `git`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 068014670982b433e8671c7b7ec821da7b469ce8. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->