### PR TITLE
docs: add activ8-ai signal intelligence artifacts

### DIFF
--- a/docs/activ8-ai/anonymized-codex-model-view.md
+++ b/docs/activ8-ai/anonymized-codex-model-view.md
@@ -1,0 +1,38 @@
+# ACTIV8 AI — Anonymized Codex Model View (Prospect-Ready)
+
+## Purpose
+This anonymized view demonstrates the Codex model architecture and weekly check-in structure without exposing client identities.
+
+## Charter-Compliant Naming Rules
+- Use anonymized identifiers (e.g., “Client A,” “Client B”) for prospect-facing assets.
+- Real client names are reserved for internal systems and weekly status reporting.
+- “Prospect Visible” labels are only used on externally distributed collateral.
+
+## Signal Flow Overview
+1. **Verbatim capture** → Transcripts ingested to `/transcripts/...`.
+2. **Live request detection** → Slack signals parsed to `/slack_threads/...`.
+3. **Operational cadence** → Teamwork task status captured in `/tasks/...`.
+4. **Deliverables** → Notion/Drive status logged to `/deliverables/...`.
+5. **Assets** → GDrive/GCS uploads stored in `/assets/...`.
+6. **Memory & reasoning** → Notebook LM updates stored in `/codex_memory/...`.
+7. **Infra visibility** → BigQuery/GCP logs stored in `/infra_logs/...`.
+8. **Reporting signals** → KPIs tracked in `/kpis/...`.
+
+## Heartbeat Example (Anonymized)
+
+| Client Name | Status | Last Check-In | Primary Source | Signals Count | Codex Trace |
+| --- | --- | --- | --- | --- | --- |
+| Client A (Anonymized) | 🟡 Yellow | 2026-01-17 | Transcript + Notion | 5 | HEARTBEAT.2026.01.21 |
+| Client B (Anonymized) | 🔴 Red | 2026-01-09 | Teamwork tasks stalled | 2 | HEARTBEAT.2026.01.21 |
+
+## Check-In Structure (Anonymized)
+- **Status:** Green / Yellow / Red
+- **Signals:** New signal count by source
+- **Wins:** Completed deliverables
+- **Risks:** Blockers and drift indicators
+- **Next Actions:** Confirmed tasks with owner + due date
+- **Codex Trace:** `HEARTBEAT.YYYY.MM.DD`
+
+## Codex Trace Reference
+- Current reference: `HEARTBEAT.2026.01.21`
+- Usage: Aligns heartbeat tables to verifiable signal logs.

--- a/docs/activ8-ai/check-in-fill-in-tool.md
+++ b/docs/activ8-ai/check-in-fill-in-tool.md
@@ -1,0 +1,29 @@
+# Check-In Fill-In Tool (Client Heartbeat)
+
+Use this template to update each active client’s weekly check-in. Store completed entries in the weekly check-in file and ensure Codex trace alignment.
+
+## Template
+
+**Client Name:**  
+**Status:** 🟢 Green / 🟡 Yellow / 🔴 Red  
+**Last Check-In Date:** YYYY-MM-DD  
+**Primary Sources:** (e.g., Slack + Teamwork)  
+**Signals Count:** #  
+
+**Wins (Completed Deliverables):**
+- 
+
+**Risks / Blockers:**
+- 
+
+**Next Actions (Owner + Due Date):**
+- 
+
+**Codex Trace:** HEARTBEAT.YYYY.MM.DD  
+
+---
+
+## Guidance
+- Use real client names for internal check-ins only.
+- Use anonymized identifiers for prospect-facing views.
+- Confirm “Prospect Visible” labels are only used on external collateral.

--- a/docs/activ8-ai/client-weekly-checkins-2026-01-21.md
+++ b/docs/activ8-ai/client-weekly-checkins-2026-01-21.md
@@ -1,0 +1,26 @@
+# Client Weekly Check-Ins — Leverage Marketing Agency (2026-01-21)
+
+**Scope:** Internal use only. Real client names permitted.  
+**Exclusions:** Keene Systems and Supreme Outdoor Living are not active clients and must not appear in check-ins.
+
+## Heartbeat Table (Live)
+
+| Client Name | Status | Last Check-In | Primary Source | Signals Count | Codex Trace |
+| --- | --- | --- | --- | --- | --- |
+| Vintage Charter & Boat Rental | 🟢 Green | 2026-01-21 | Slack + Teamwork | 11 | HEARTBEAT.2026.01.21 |
+
+## Weekly Check-In Details
+
+### Vintage Charter & Boat Rental
+- **Status:** 🟢 Green
+- **Signals captured:** Slack requests + Teamwork task updates
+- **Wins:** Charter calendar refresh delivered, seasonal promo copy finalized
+- **Risks:** None flagged this week
+- **Next actions:**
+  - Publish updated promo assets to GDrive/GCS (Owner: Content Ops, Due: 2026-01-24)
+  - Schedule Q1 review call (Owner: Client Success, Due: 2026-01-25)
+- **Codex trace:** HEARTBEAT.2026.01.21
+
+## Notes
+- Add new active clients below as they are onboarded.
+- Keep all client naming internal; anonymize for prospect-facing exports.

--- a/docs/activ8-ai/signal-intelligence-architecture-2026-01-21.md
+++ b/docs/activ8-ai/signal-intelligence-architecture-2026-01-21.md
@@ -1,0 +1,38 @@
+# ACTIV8 AI — Signal Intelligence Architecture (2026-01-21)
+
+## Charter Clarifications
+- Keene Systems and Supreme Outdoor Living are no longer active clients.
+- Their data is approved for anonymized model views only, not active client check-ins.
+- Client Weekly Check-Ins are **only** for active Leverage Marketing Agency clients.
+- “Prospect Visible” should only appear on externally used prospecting collateral.
+
+## Signal Grid (Warehouse + Intelligence)
+
+| Signal Type | Source | Charter Role | Output Path |
+| --- | --- | --- | --- |
+| 🎥 Verbatim Transcripts | Fathom / Zoom / Meet | Human-voice to Codex | `/transcripts/...` |
+| 💬 Client Chat | Slack DM + Channels | Live request detection | `/slack_threads/...` |
+| ✅ Tasks & Status | Teamwork | Operational cadence + logging | `/tasks/...` |
+| 📁 Deliverables & Docs | Notion / Google Drive | Proposal/brief status, completion | `/deliverables/...` |
+| 📦 Assets & Uploads | GDrive, GCS | Warehouse of client work | `/assets/...` |
+| 📓 Notebook LM | Memory context, agent notes | 🧠 SigNIT — live reasoning trails | `/codex_memory/...` |
+| 🔍 BigQuery / GCP Logs | Usage, error reports | Deployment tracking, infra drift | `/infra_logs/...` |
+| 📊 LookerStudio / Sheets | KPIs, dashboards, budgets | Reporting signals | `/kpis/...` |
+
+## Notebook LM vs Warehouse
+
+| Feature | Notebook LM | Data Warehouses (GDrive, GCP) |
+| --- | --- | --- |
+| Signal Type | SigNIT (Intelligence) | Raw or enriched data assets |
+| Author | Agent-generated or human input | Client-uploaded or internal upload |
+| Codex Role | Memory, logic, reasoning threads | Source of truth, audit, documentation |
+| Processing | Ingested via Codex trace + MCP agents | Swept via charter-sweep-agent |
+| Usage | Decision support, context expansion | Evidence, reference, work product |
+
+**Notebook LM = Dynamic Memory.**  
+**Warehouses = Static Knowledge & Artifacts.**
+
+## Registration
+- Registered under Codex as: `SIGNALS.2026.01.21.ACTIV8`.
+- Registered under MCP as: `mcp://activ8/signals/2026-01-21`.
+- Canonical owner: Activ8 AI Signal Intelligence Model (Charter-Compliant).


### PR DESCRIPTION
### Motivation
- Provide a canonical signal intelligence architecture and supporting artifacts to standardize client heartbeats and signal handling across the Codex and MCP systems.
- Capture a prospect-safe anonymized view and internal check-in templates to enforce charter-compliant naming and exposure rules.
- Record a snapshot heartbeat and registration metadata for 2026-01-21 to align traces and provenance with Codex conventions.

### Description
- Added `docs/activ8-ai/signal-intelligence-architecture-2026-01-21.md`, `docs/activ8-ai/anonymized-codex-model-view.md`, `docs/activ8-ai/client-weekly-checkins-2026-01-21.md`, and `docs/activ8-ai/check-in-fill-in-tool.md` containing the new signal intelligence guidance and templates.
- The architecture doc defines the signal grid, `Notebook LM` vs warehouse distinctions, and registration identifiers `SIGNALS.2026.01.21.ACTIV8` and `mcp://activ8/signals/2026-01-21`.
- The anonymized view and check-in artifacts include heartbeat examples and guidance on `HEARTBEAT.2026.01.21` trace usage and internal vs prospect-facing naming rules.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697208cadcc08331ac3090ff67e4d77a)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces Activ8 AI documentation to standardize signal handling and weekly client heartbeats.
> 
> - Adds `signal-intelligence-architecture-2026-01-21.md` defining the signal grid, `Notebook LM` vs warehouse distinctions, and registrations `SIGNALS.2026.01.21.ACTIV8` / `mcp://activ8/signals/2026-01-21`
> - Adds `anonymized-codex-model-view.md` with prospect-safe heartbeat example and naming rules, referencing `HEARTBEAT.2026.01.21`
> - Adds `client-weekly-checkins-2026-01-21.md` (internal) with live heartbeat entry and explicit exclusions for non-active clients
> - Adds `check-in-fill-in-tool.md` template for weekly updates, reinforcing internal vs prospect-facing naming and Codex trace `HEARTBEAT.YYYY.MM.DD`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7125bbd1a998c68b64b819cb1718522bfbb60ee8. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->