### PR TITLE
Add canonical Claude/Notion webhook routes with backward-compatible aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,7 +565,7 @@ Multi‑Agent Orchestration
 
 - Enqueue handoff: tool `enqueueHandoff`
 - Dispatch queued events: `npm run orchestrator:dispatch` (routes to Notion Relay / Prime / Claude adapters)
-- Notion Relay webhooks: `npm run relay:serve` (endpoints: `/webhook/prime`, `/webhook/clawed`, `/webhook/ancillary`)
+- Notion Relay webhooks: `npm run relay:serve` (endpoints: `/webhook/prime`, `/webhook/claude`, `/webhook/notion` (legacy aliases: `/webhook/clawed`, `/webhook/ancillary`))
 
 > Note: This repo contains the **Teamwork MCP** plus a **Notion Relay webhook server**.  
 > The **Notion MCP server** (via `activ8-unified-mcp`) lives in the `Activ8-AI/mcp` monorepo; see [`docs/activ8-unified-mcp-notion-server-setup.md`](./docs/activ8-unified-mcp-notion-server-setup.md).

--- a/docs/notion-portal.md
+++ b/docs/notion-portal.md
@@ -26,8 +26,8 @@ Relay Webhooks
 --------------
 
 - Prime → POST /webhook/prime
-- Clawed → POST /webhook/clawed
-- Ancillary → POST /webhook/ancillary
+- Claude → POST /webhook/claude (legacy alias: /webhook/clawed)
+- Notion → POST /webhook/notion (legacy alias: /webhook/ancillary)
 
 Payload (example)
 ```json

--- a/src/servers/notion-relay-server.ts
+++ b/src/servers/notion-relay-server.ts
@@ -96,26 +96,26 @@ app.post('/webhook/prime', verifyRequest, async (req, res) => {
   }
 });
 
-app.post('/webhook/clawed', verifyRequest, async (req, res) => {
+async function handleClaudeWebhook(req: express.Request, res: express.Response) {
   try {
     const payload = req.body || {};
     await enqueue({
-      title: payload.task || payload.task_id || 'Clawed In-Flight',
+      title: payload.task || payload.task_id || 'Claude In-Flight',
       description: `Stage: ${payload.action || 'In-Flight'}`,
-      targets: toTargets('clawed')
+      targets: toTargets('claude')
     });
     res.json({ ok: true });
   } catch (e: any) {
     logger.error(e.message);
     res.status(500).json({ ok: false, error: e.message });
   }
-});
+}
 
-app.post('/webhook/ancillary', verifyRequest, async (req, res) => {
+async function handleNotionWebhook(req: express.Request, res: express.Response) {
   try {
     const payload = req.body || {};
     await enqueue({
-      title: payload.task || payload.task_id || 'Ancillary Review',
+      title: payload.task || payload.task_id || 'Notion Review',
       description: `Stage: ${payload.action || 'Review'}`,
       targets: [{ name: 'NotionRelay' }]
     });
@@ -124,7 +124,15 @@ app.post('/webhook/ancillary', verifyRequest, async (req, res) => {
     logger.error(e.message);
     res.status(500).json({ ok: false, error: e.message });
   }
-});
+}
+
+app.post('/webhook/claude', verifyRequest, handleClaudeWebhook);
+// Backward compatible alias.
+app.post('/webhook/clawed', verifyRequest, handleClaudeWebhook);
+
+app.post('/webhook/notion', verifyRequest, handleNotionWebhook);
+// Backward compatible alias.
+app.post('/webhook/ancillary', verifyRequest, handleNotionWebhook);
 
   return app;
 }


### PR DESCRIPTION
### Motivation

- Expose clear, canonical relay endpoints for Claude and Notion to improve integration clarity and remove reliance on legacy route names. 
- Preserve existing callers by providing backward-compatible aliases so upgrades don't break integrations. 
- Refactor handlers to make Claude/Notion webhook logic reusable and easier to maintain.

### Description

- Added explicit handler functions `handleClaudeWebhook` and `handleNotionWebhook` and wired canonical routes `/webhook/claude` and `/webhook/notion` in `src/servers/notion-relay-server.ts`. 
- Kept legacy aliases `/webhook/clawed` and `/webhook/ancillary` pointing to the new handlers and adjusted default `title` and `targets` for Claude/Notion payloads. 
- Updated documentation in `README.md` and `docs/notion-portal.md` to list the new canonical endpoints and note the legacy aliases. 
- Added a contract test in `tests/relay-contract.test.js` to verify the new routes accept properly signed requests.

### Testing

- Ran `npm test` which builds the project and executes the relay tests. 
- All relay-related tests passed (`4` tests ran, `0` failures). 
- The added integration test asserting `/webhook/claude` and `/webhook/notion` accept signed payloads passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6984b01545e483318289890c9c548495)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized changes to webhook routing and payload labeling; main risk is breaking existing integrations, mitigated by keeping backward-compatible aliases and adding a contract test.
> 
> **Overview**
> Adds canonical Notion Relay webhook endpoints `POST /webhook/claude` and `POST /webhook/notion`, while keeping `POST /webhook/clawed` and `POST /webhook/ancillary` as backward-compatible aliases.
> 
> Refactors the relay server to reuse new handler functions and updates the default enqueue `title`/`targets` labeling for Claude/Notion webhooks. Documentation is updated to reflect the new canonical routes, and a contract test verifies the new endpoints accept properly signed requests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b3c521ca980c8381643016cb9a9700b90fb23f4. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->