### PR TITLE
fix(deps): bump qs override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1804,9 +1804,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "winston": "^3.12.0"
   },
   "overrides": {
-    "qs": "6.14.1"
+    "qs": "6.15.0"
   },
   "devDependencies": {
     "@types/body-parser": "^1.19.6",


### PR DESCRIPTION
## Summary
- Bump the `qs` override to `6.15.0` to clear the low-severity advisory reported by `npm audit`.

## Testing
- `npm test`
- `npm audit --audit-level=high`

## Security
- Removes the `qs` advisory reported on `main` (DoS via comma parsing arrayLimit bypass).
